### PR TITLE
format mac hints according to guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ When the user presses a hotkey, KeyUX will click on the button or link
 with the same hotkey in `aria-keyshortcuts`.
 
 For instance, KeyUX will click on this button if user press
-<kbd>Alt</kbd>+<kbd>B</kbd> or <kbd>⌥</kbd> <kbd>B</kbd>.
+<kbd>Alt</kbd>+<kbd>B</kbd> or <kbd>⌥</kbd> <kbd>B</kbd>.
 
 ```js
 <button aria-keyshortcuts="alt+b">Bold</button>
@@ -110,7 +110,7 @@ to be able to use hotkeys (but it is still possible by connecting an
 external keyboard).
 
 `getHotKeyHint()` replaces modifiers for Mac and makes text prettier.
-For instance, for `alt+b` it will return `Alt + B` on Windows/Linux or `⌥ B`
+For instance, for `alt+b` it will return `Alt + B` on Windows/Linux or `⌥ B`
 on Mac.
 
 
@@ -159,7 +159,7 @@ const overrides = {
 ```
 
 Then KeyUX will click on `aria-keyshortcuts="b"` when <kbd>Alt</kbd>+<kbd>B</kbd>
-is pressed, and `getHotKeyHint(window, 'b', overrides)` will return `Alt + B`/`⌥ B`.
+is pressed, and `getHotKeyHint(window, 'b', overrides)` will return `Alt + B`/`⌥ B`.
 
 
 ### Menu

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ When the user presses a hotkey, KeyUX will click on the button or link
 with the same hotkey in `aria-keyshortcuts`.
 
 For instance, KeyUX will click on this button if user press
-<kbd>Alt</kbd>+<kbd>B</kbd> or <kbd>⌥</kbd>+<kbd>B</kbd>.
+<kbd>Alt</kbd>+<kbd>B</kbd> or <kbd>⌥</kbd> <kbd>B</kbd>.
 
 ```js
 <button aria-keyshortcuts="alt+b">Bold</button>

--- a/index.js
+++ b/index.js
@@ -28,25 +28,13 @@ export function getHotKeyHint(window, code, overrides = {}) {
     .split('+')
     .map(part => part[0].toUpperCase() + part.slice(1))
   if (window.navigator.platform.indexOf('Mac') === 0) {
-    return sortMacKeys(prettyParts)
-      .join(' ')
-      .replace('Meta', '⌘')
-      .replace('Ctrl', '⌃')
-      .replace('Alt', '⌥')
-      .replace('Shift', '⇧')
+    return prettyParts
+      .join('')
+      .replace(/(.*)Meta(.*)/, '⌘$1$2')
+      .replace(/(.*)Shift(.*)/, '⇧$1$2')
+      .replace(/(.*)Alt(.*)/, '⌥$1$2')
+      .replace(/(.*)Ctrl(.*)/, '⌃$1$2')
   } else {
     return prettyParts.join(' + ')
   }
-}
-
-function sortMacKeys(keys) {
-  let keyOrder = ['Ctrl', 'Alt', 'Shift', 'Meta']
-  return keys.sort((a, b) => {
-    let aIndex = keyOrder.indexOf(a)
-    let bIndex = keyOrder.indexOf(b)
-    return (
-      (aIndex >= 0 ? aIndex : keyOrder.length) -
-      (bIndex >= 0 ? bIndex : keyOrder.length)
-    )
-  })
 }

--- a/index.js
+++ b/index.js
@@ -24,17 +24,29 @@ export function getHotKeyHint(window, code, overrides = {}) {
       break
     }
   }
-  let pretty = realCode
+  let prettyParts = realCode
     .split('+')
     .map(part => part[0].toUpperCase() + part.slice(1))
-    .join(' + ')
   if (window.navigator.platform.indexOf('Mac') === 0) {
-    return pretty
+    return sortMacKeys(prettyParts)
+      .join(' ')
       .replace('Meta', '⌘')
       .replace('Ctrl', '⌃')
       .replace('Alt', '⌥')
       .replace('Shift', '⇧')
   } else {
-    return pretty
+    return prettyParts.join(' + ')
   }
+}
+
+function sortMacKeys(keys) {
+  let keyOrder = ['Ctrl', 'Alt', 'Shift', 'Meta']
+  return keys.sort((a, b) => {
+    let aIndex = keyOrder.indexOf(a)
+    let bIndex = keyOrder.indexOf(b)
+    return (
+      (aIndex >= 0 ? aIndex : keyOrder.length) -
+      (bIndex >= 0 ? bIndex : keyOrder.length)
+    )
+  })
 }

--- a/index.js
+++ b/index.js
@@ -30,10 +30,10 @@ export function getHotKeyHint(window, code, overrides = {}) {
   if (window.navigator.platform.indexOf('Mac') === 0) {
     return prettyParts
       .join('')
-      .replace(/(.*)Meta(.*)/, '⌘$1$2')
-      .replace(/(.*)Shift(.*)/, '⇧$1$2')
-      .replace(/(.*)Alt(.*)/, '⌥$1$2')
-      .replace(/(.*)Ctrl(.*)/, '⌃$1$2')
+      .replace(/(.*)Meta(.*)/, '⌘ $1$2')
+      .replace(/(.*)Shift(.*)/, '⇧ $1$2')
+      .replace(/(.*)Alt(.*)/, '⌥ $1$2')
+      .replace(/(.*)Ctrl(.*)/, '⌃ $1$2')
   } else {
     return prettyParts.join(' + ')
   }

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
       "import": {
         "./index.js": "{ startKeyUX, hotkeyKeyUX, pressKeyUX, menuKeyUX, jumpKeyUX, hiddenKeyUX, likelyWithKeyboard, getHotKeyHint }"
       },
-      "limit": "1590 B"
+      "limit": "1586 B"
     }
   ],
   "clean-publish": {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
       "import": {
         "./index.js": "{ startKeyUX, hotkeyKeyUX, pressKeyUX, menuKeyUX, jumpKeyUX, hiddenKeyUX, likelyWithKeyboard, getHotKeyHint }"
       },
-      "limit": "1586 B"
+      "limit": "1596 B"
     }
   ],
   "clean-publish": {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -38,6 +38,6 @@ test('makes hotkey hint prettier', () => {
 })
 
 test('makes mac hotkey hint prettier', () => {
-  equal(getHotKeyHint(MAC_WINDOW, 'alt+b'), '⌥B')
-  equal(getHotKeyHint(MAC_WINDOW, 'meta+ctrl+shift+alt+b'), '⌃⌥⇧⌘B')
+  equal(getHotKeyHint(MAC_WINDOW, 'alt+b'), '⌥ B')
+  equal(getHotKeyHint(MAC_WINDOW, 'meta+ctrl+shift+alt+b'), '⌃ ⌥ ⇧ ⌘ B')
 })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -31,5 +31,9 @@ test('makes hotkey hint prettier', () => {
   let window = new JSDOM().window
   equal(getHotKeyHint(window, 'alt+b'), 'Alt + B')
   equal(getHotKeyHint(window, 'alt+b', { b: 'alt+b' }), 'B')
-  equal(getHotKeyHint(MAC_WINDOW, 'alt+b'), '⌥ + B')
+})
+
+test('makes mac hotkey hint prettier', () => {
+  equal(getHotKeyHint(MAC_WINDOW, 'alt+b'), '⌥ B')
+  equal(getHotKeyHint(MAC_WINDOW, 'meta+ctrl+shift+alt+b'), '⌃ ⌥ ⇧ ⌘ B')
 })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -30,10 +30,14 @@ test('detects keyboard', () => {
 test('makes hotkey hint prettier', () => {
   let window = new JSDOM().window
   equal(getHotKeyHint(window, 'alt+b'), 'Alt + B')
+  equal(
+    getHotKeyHint(window, 'meta+ctrl+shift+alt+b'),
+    'Meta + Ctrl + Shift + Alt + B'
+  )
   equal(getHotKeyHint(window, 'alt+b', { b: 'alt+b' }), 'B')
 })
 
 test('makes mac hotkey hint prettier', () => {
-  equal(getHotKeyHint(MAC_WINDOW, 'alt+b'), '⌥ B')
-  equal(getHotKeyHint(MAC_WINDOW, 'meta+ctrl+shift+alt+b'), '⌃ ⌥ ⇧ ⌘ B')
+  equal(getHotKeyHint(MAC_WINDOW, 'alt+b'), '⌥B')
+  equal(getHotKeyHint(MAC_WINDOW, 'meta+ctrl+shift+alt+b'), '⌃⌥⇧⌘B')
 })


### PR DESCRIPTION
MacOS has specific guidelines regarding how hotkey shortcuts should be represented. Most importantly, they should be listed in a [specific order](https://developer.apple.com/design/human-interface-guidelines/keyboards#:~:text=List%20modifier%20keys%20in%20the%20correct%20order.%20If%20you%20use%20more%20than%20one%20modifier%20key%20in%20a%20custom%20shortcut%2C%20always%20list%20them%20in%20this%20order%3A%20Control%2C%20Option%2C%20Shift%2C%20Command.) (Ctrl, Alt, Shift, Meta), and the plus sign is not used a delimiter:

![image](https://github.com/ai/keyux/assets/975978/b0b935a4-e576-4350-bd89-16a4754e2c0b)

This PR implements those recommendations.