### PR TITLE
change the canonical order of modifiers to align with Windows guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ For instance, KeyUX will click on this button if user press
 <button aria-keyshortcuts="alt+b">Bold</button>
 ```
 
-The hotkey pattern should contain modifiers like `meta+ctrl+shift+alt+b` in this exact order.
+The hotkey pattern should contain modifiers like `meta+ctrl+alt+shift+b` in this exact order.
 
 To enable this feature, call `hotkeyKeyUX`:
 

--- a/hotkey.js
+++ b/hotkey.js
@@ -24,8 +24,8 @@ function findHotKey(event, where, overrides) {
   let prefix = ''
   if (event.metaKey) prefix += 'meta+'
   if (event.ctrlKey) prefix += 'ctrl+'
-  if (event.shiftKey) prefix += 'shift+'
   if (event.altKey) prefix += 'alt+'
+  if (event.shiftKey) prefix += 'shift+'
 
   let code = prefix
   if (event.key === '+') {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
       "import": {
         "./index.js": "{ startKeyUX, hotkeyKeyUX, pressKeyUX, menuKeyUX, jumpKeyUX, hiddenKeyUX, likelyWithKeyboard, getHotKeyHint }"
       },
-      "limit": "1596 B"
+      "limit": "1606 B"
     }
   ],
   "clean-publish": {

--- a/test/hotkey.test.ts
+++ b/test/hotkey.test.ts
@@ -23,7 +23,7 @@ test('adds hot keys to buttons and links', () => {
     '<button aria-keyshortcuts="b">1</button>' +
     '<button aria-keyshortcuts="Ctrl+B">10</button>' +
     '<button aria-keyshortcuts="plus">100</button>' +
-    '<a href="#" aria-keyshortcuts="meta+ctrl+shift+alt+b">1000</a>'
+    '<a href="#" aria-keyshortcuts="meta+ctrl+alt+shift+b">1000</a>'
 
   let result = 0
   let buttons = window.document.querySelectorAll('button, a')

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -39,5 +39,5 @@ test('makes hotkey hint prettier', () => {
 
 test('makes mac hotkey hint prettier', () => {
   equal(getHotKeyHint(MAC_WINDOW, 'alt+b'), '⌥ B')
-  equal(getHotKeyHint(MAC_WINDOW, 'meta+ctrl+shift+alt+b'), '⌃ ⌥ ⇧ ⌘ B')
+  equal(getHotKeyHint(MAC_WINDOW, 'meta+ctrl+alt+shift+b'), '⌃ ⌥ ⇧ ⌘ B')
 })


### PR DESCRIPTION
Follow-up to https://github.com/ai/keyux/pull/5#issuecomment-1961329673.

Turns out, Windows have an opinion on the canonical order of modifier keys as well. It should be Meta (Win), Ctrl, Alt, Shift.

This PR changes the order of modifiers required in `aria-keyshortcuts` to align with this guideline.