### PR TITLE
add mac compatibility mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,3 +431,26 @@ startKeyUX(window, [
   hiddenKeyUX()
 ])
 ```
+
+
+### Mac Compatibility Mode
+
+It's common to use the Meta (<kbd>⌘</kbd>) modifier for hotkeys on Mac, while
+Window and Linux usually favor the Ctrl key. To provide familiar experience on
+all platforms, enable the Mac compatibility transform:
+
+```js
+import {
+  hotkeyMacCompat,
+  hotkeyKeyUX,
+  startKeyUX,
+  getHotKeyHint
+} from 'keyux'
+
+const macCompat = hotkeyMacCompat();
+startKeyUX(window, [hotkeyKeyUX([macCompat])])
+getHotKeyHint(window, 'ctrl+b', [macCompat])
+```
+
+Hotkeys pressed with the Meta modifier will work as if the Ctrl modifier was
+pressed.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ external keyboard).
 For instance, for `alt+b` it will return `Alt + B` on Windows/Linux or `⌥ B`
 on Mac.
 
-If you're using overrides, pass the same override config both to `hotkeyKeyUX()`
+If you’re using overrides, pass the same override config both to `hotkeyKeyUX()`
 and `getHotKeyHint()` for accurate hints:
 
 ```js
@@ -435,9 +435,9 @@ startKeyUX(window, [
 
 ### Mac Compatibility Mode
 
-It's common to use the Meta (<kbd>⌘</kbd>) modifier for hotkeys on Mac, while
-Window and Linux usually favor the Ctrl key. To provide familiar experience on
-all platforms, enable the Mac compatibility transform:
+It’s common to use the <kbd>Meta</kbd> (or <kbd>⌘</kbd>) modifier for hotkeys
+on Mac, while Window and Linux usually favor the <kbd>Ctrl</kbd> key. To provide
+familiar experience on all platforms, enable the Mac compatibility transform:
 
 ```js
 import {
@@ -452,5 +452,5 @@ startKeyUX(window, [hotkeyKeyUX([macCompat])])
 getHotKeyHint(window, 'ctrl+b', [macCompat])
 ```
 
-Hotkeys pressed with the Meta modifier will work as if the Ctrl modifier was
-pressed.
+Hotkeys pressed with the <kbd>Meta</kbd> modifier will work as if the <kbd>Ctrl</kbd>
+modifier was pressed.

--- a/compat.js
+++ b/compat.js
@@ -1,10 +1,3 @@
-export function hotkeyMacCompat() {
-  return [
-    (code, window) => maybeApplyCompat(code, window, 'meta', 'ctrl'),
-    (code, window) => maybeApplyCompat(code, window, 'ctrl', 'meta')
-  ]
-}
-
 function maybeApplyCompat(code, window, from, to) {
   if (
     window.navigator.platform.indexOf('Mac') === 0 &&
@@ -13,4 +6,12 @@ function maybeApplyCompat(code, window, from, to) {
     return code.replace(from, to)
   }
   return code
+}
+
+
+export function hotkeyMacCompat() {
+  return [
+    (code, window) => maybeApplyCompat(code, window, 'meta', 'ctrl'),
+    (code, window) => maybeApplyCompat(code, window, 'ctrl', 'meta')
+  ]
 }

--- a/compat.js
+++ b/compat.js
@@ -1,0 +1,16 @@
+export function hotkeyMacCompat() {
+  return [
+    (code, window) => maybeApplyCompat(code, window, 'meta', 'ctrl'),
+    (code, window) => maybeApplyCompat(code, window, 'ctrl', 'meta')
+  ]
+}
+
+function maybeApplyCompat(code, window, from, to) {
+  if (
+    window.navigator.platform.indexOf('Mac') === 0 &&
+    !code.includes('meta+ctrl')
+  ) {
+    return code.replace(from, to)
+  }
+  return code
+}

--- a/compat.js
+++ b/compat.js
@@ -8,7 +8,6 @@ function maybeApplyCompat(code, window, from, to) {
   return code
 }
 
-
 export function hotkeyMacCompat() {
   return [
     (code, window) => maybeApplyCompat(code, window, 'meta', 'ctrl'),

--- a/index.d.ts
+++ b/index.d.ts
@@ -186,3 +186,9 @@ export function getHotKeyHint(
  * ```
  */
 export function hotkeyOverrides(overrides: HotkeyOverride): Transformer
+
+/**
+ * Provides a transformer for Mac compatibility mode that can be used
+ * with `hotkeyKeyUX()` and `getHotKeyHint()`.
+ */
+export function hotkeyMacCompat(): Transformer

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ export * from './hidden.js'
 export * from './press.js'
 export * from './jump.js'
 export * from './overrides.js'
+export * from './compat.js'
 
 export function startKeyUX(window, plugins) {
   let unbinds = plugins.map(plugin => plugin(window))

--- a/package.json
+++ b/package.json
@@ -83,9 +83,9 @@
     {
       "name": "All modules",
       "import": {
-        "./index.js": "{ startKeyUX, hotkeyKeyUX, pressKeyUX, focusGroupKeyUX, jumpKeyUX, hiddenKeyUX, likelyWithKeyboard, getHotKeyHint, hotkeyOverrides }"
+        "./index.js": "{ startKeyUX, hotkeyKeyUX, pressKeyUX, focusGroupKeyUX, jumpKeyUX, hiddenKeyUX, likelyWithKeyboard, getHotKeyHint, hotkeyOverrides, hotkeyMacCompat }"
       },
-      "limit": "1996 B"
+      "limit": "2056 B"
     }
   ],
   "clean-publish": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
       "import": {
         "./index.js": "{ startKeyUX, hotkeyKeyUX, pressKeyUX, focusGroupKeyUX, jumpKeyUX, hiddenKeyUX, likelyWithKeyboard, getHotKeyHint, hotkeyOverrides, hotkeyMacCompat }"
       },
-      "limit": "2056 B"
+      "limit": "2059 B"
     }
   ],
   "clean-publish": {

--- a/test/compat.test.ts
+++ b/test/compat.test.ts
@@ -1,0 +1,30 @@
+import { JSDOM } from 'jsdom'
+import { equal } from 'node:assert'
+import { test } from 'node:test'
+
+import { hotkeyMacCompat } from '../compat.js'
+import type { MinimalWindow } from '../index.js'
+
+const MAC_WINDOW = {
+  navigator: {
+    platform: 'Mac',
+    userAgent: 'Mac'
+  }
+} as MinimalWindow
+
+const [tranformForward, transformReverse] = hotkeyMacCompat()
+
+test('applies hotkey compatibility for Mac platform', () => {
+  equal(tranformForward('meta+shift+b', MAC_WINDOW), 'ctrl+shift+b')
+  equal(tranformForward('meta+ctrl+shift+b', MAC_WINDOW), 'meta+ctrl+shift+b')
+})
+
+test('applies hint compatibility for Mac platform', () => {
+  equal(transformReverse('ctrl+shift+b', MAC_WINDOW), 'meta+shift+b')
+  equal(transformReverse('meta+ctrl+shift+b', MAC_WINDOW), 'meta+ctrl+shift+b')
+})
+
+test('does nothing for non-Mac platform', () => {
+  equal(tranformForward('meta+shift+b', new JSDOM().window), 'meta+shift+b')
+  equal(transformReverse('ctrl+shift+b', new JSDOM().window), 'ctrl+shift+b')
+})

--- a/test/demo/index.tsx
+++ b/test/demo/index.tsx
@@ -7,6 +7,7 @@ import {
   getHotKeyHint,
   hiddenKeyUX,
   hotkeyKeyUX,
+  hotkeyMacCompat,
   hotkeyOverrides,
   jumpKeyUX,
   likelyWithKeyboard,
@@ -16,9 +17,10 @@ import {
 
 let overrides: HotkeyOverride = {}
 let overridesTransformer = hotkeyOverrides(overrides)
+let macCompatTransformer = hotkeyMacCompat()
 
 startKeyUX(window, [
-  hotkeyKeyUX([overridesTransformer]),
+  hotkeyKeyUX([macCompatTransformer, overridesTransformer]),
   focusGroupKeyUX(),
   pressKeyUX('is-pressed'),
   jumpKeyUX(),
@@ -27,7 +29,12 @@ startKeyUX(window, [
 
 const HotKeyHint: FC<{ hotkey: string }> = ({ hotkey }) => {
   return likelyWithKeyboard(window) ? (
-    <kbd>{getHotKeyHint(window, hotkey, [overridesTransformer])}</kbd>
+    <kbd>
+      {getHotKeyHint(window, hotkey, [
+        overridesTransformer,
+        macCompatTransformer
+      ])}
+    </kbd>
   ) : null
 }
 
@@ -345,15 +352,9 @@ const Toolbar: FC = () => {
     <>
       <div className="toolbar" role="toolbar">
         <div className="toolbar_group">
-          <button className="toolbar_button" type="button">
-            Copy
-          </button>
-          <button className="toolbar_button" type="button">
-            Paste
-          </button>
-          <button className="toolbar_button" type="button">
-            Cut
-          </button>
+          <button className="toolbar_button" type="button">Copy</button>
+          <button className="toolbar_button" type="button">Paste</button>
+          <button className="toolbar_button" type="button">Cut</button>
         </div>
         <div className="toolbar_group">
           <label className="toolbar_label">

--- a/test/demo/index.tsx
+++ b/test/demo/index.tsx
@@ -15,7 +15,7 @@ import {
 } from '../../index.js'
 
 let overrides: HotkeyOverride = {}
-let overridesTransformer = hotkeyOverrides(overrides);
+let overridesTransformer = hotkeyOverrides(overrides)
 
 startKeyUX(window, [
   hotkeyKeyUX([overridesTransformer]),
@@ -343,15 +343,21 @@ const Tabs: FC = () => {
 const Toolbar: FC = () => {
   return (
     <>
-      <div className='toolbar' role="toolbar">
+      <div className="toolbar" role="toolbar">
         <div className="toolbar_group">
-          <button className="toolbar_button" type="button">Copy</button>
-          <button className="toolbar_button" type="button">Paste</button>
-          <button className="toolbar_button" type="button">Cut</button>
+          <button className="toolbar_button" type="button">
+            Copy
+          </button>
+          <button className="toolbar_button" type="button">
+            Paste
+          </button>
+          <button className="toolbar_button" type="button">
+            Cut
+          </button>
         </div>
         <div className="toolbar_group">
           <label className="toolbar_label">
-            <input type="checkbox"/>
+            <input type="checkbox" />
             Night Mode
           </label>
         </div>


### PR DESCRIPTION
This change is potentially controversial, so consider it RFC rather than something final :)

On Mac a common modifier for hotkeys is Meta (aka Cmd, aka `⌘`), while Ctrl is usually avoided. On the other hand, it's very uncommon for the Meta key to be used for app-level hotkeys on Windows or Linux.

To provide a familiar experience for users on all platforms, I suggest the Mac compatibility mode, which treats the Meta modifier as if it is Ctrl on Macs (unless both are used). So on Mac `meta+b` invokes `ctrl+b`, `meta+ctrl+b` still invokes `meta+ctrl+b`.

~~To keep the API minimal, I'm piggybacking on top of the `overrides` object, because basically this is a special kind of an override. A special opaque object `MAC_COMPAT` is exported, which can be mixed in with the rest of the overrides.~~

```js
import { hotkeyKeyUX, startKeyUX, MAC_COMPAT } from 'keyux'

startKeyUX(window, [
  hotkeyKeyUX({ ...MAC_COMPAT })
])
```

`getHotKeyHint` also supports this and renders Ctrl as `⌘`.

I'm open to all suggestions regarding the API and the idea in general.