### PR TITLE
Ignore events in contentEditable elements

### DIFF
--- a/hotkey.js
+++ b/hotkey.js
@@ -94,6 +94,7 @@ export function hotkeyKeyUX(transformers = []) {
       if (
         !event.altKey &&
         (event.target.tagName === 'TEXTAREA' ||
+          event.target.isContentEditable ||
           (event.target.tagName === 'INPUT' &&
             !IGNORE_INPUTS[event.target.type]) ||
           event.target.role === 'menuitem')

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
       "import": {
         "./index.js": "{ startKeyUX, hotkeyKeyUX, pressKeyUX, focusGroupKeyUX, jumpKeyUX, hiddenKeyUX, likelyWithKeyboard, getHotKeyHint, hotkeyOverrides, hotkeyMacCompat }"
       },
-      "limit": "2132 B"
+      "limit": "2144 B"
     }
   ],
   "clean-publish": {

--- a/test/hotkey.test.ts
+++ b/test/hotkey.test.ts
@@ -100,6 +100,8 @@ test('ignores hot keys when focus is inside text fields', () => {
   press(window, { key: 'b' }, window.document.querySelector('textarea')!)
   equal(clicked, 0)
 
+  // TODO: Add tests for conteneditable (currently, JSDOM doesn't support it)
+
   press(window, { key: 'b' }, window.document.querySelector('a')!)
   equal(clicked, 1)
 


### PR DESCRIPTION
When using some rich editor (Prosemirror, Lexical, etc...) which is based on `contenteditable="true"` property, keyboard events during typing there aren't ignored, though should be.

> [!WARNING]
> I haven't added tests, since [JSDOM doesn't support](https://github.com/jsdom/jsdom/issues/1670) `isContentEditable` property