### PR TITLE
Use event.timeStamp for typing delay

### DIFF
--- a/focus-group.js
+++ b/focus-group.js
@@ -94,13 +94,12 @@ export function focusGroupKeyUX(options) {
         event.preventDefault()
         focus(event.target, items[items.length - 1])
       } else if (event.key.length === 1 && group.role !== 'tablist') {
-        let now = Date.now()
-        if (now - lastTyped <= typingDelayMs) {
+        if (event.timeStamp - lastTyped <= typingDelayMs) {
           searchPrefix += event.key.toLowerCase()
         } else {
           searchPrefix = event.key.toLowerCase()
         }
-        lastTyped = now
+        lastTyped = event.timeStamp
 
         let found = Array.from(items).find(item => {
           return item.textContent


### PR DESCRIPTION
I suggest using `event.timeStamp` for calculating the typing delay, instead of `Date.now()`.

---

Currently the delay between keystrokes is calculated based on `Date.now()`. There are two potential issues with that:

## What `now` is?

`Date.now()` is a "wall clock" time, meaning it can change suddenly, towards the future or the past.

_An example would be having Windows and Linux in dual-boot on the same machine. Linux typically keeps system clock in UTC and Windows keeps that in the local TZ. For a Windows user (and its browser) the re-sync looks like a sudden leap of `Date.now()` values that happens eventually after the system is booted up._

`event::timeStamp` uses a monotonic timer that **doesn't depend on the system clock corrections**.

## When `now` is?

`Date.now()` reports the current time, well, _now_. As the JS function is evaluated in the macro-task created for the Event dispatch.
We could assume that the time a user presses the key and the time "now" is roughly the same. But it could not be the case when the JS even loop is very busy.

Sadly, blocking an event loop for 300 ms is something we could expect in the modern Web. The difference between two `Date.now()` calls could be greater than 300 just because something heavy was running at the background.

`event::timeStamp`, on the other hand, is the timestamp of a moment when the key was actually pressed. I.e., when the event was _scheduled_, not when it is _dispatched_. So it is **unaffected by the event loop jank**.