### PR TITLE
Support switching focusgroup wrap behaviors

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,8 +306,9 @@ by arrows.
 Key UX supports (you can combine these features):
 - `focusgroup="block"` for vertical arrows.
 - `focusgroup="no-memory"` to not restore last focus position.
+- `focusgroup="wrap"` enables cyclic focus movement within a group.
 
-Key UX doesn’t support `wrap`, `none`, and `grid` features.
+Key UX doesn’t support `none` and `grid` features.
 
 ### Menu
 

--- a/focus-group.js
+++ b/focus-group.js
@@ -91,10 +91,24 @@ export function focusGroupKeyUX(options) {
 
       if (event.key === nextKey) {
         event.preventDefault()
-        focus(event.target, items[index + 1] || items[0])
+        if (group.hasAttribute('focusgroup')) {
+          items[index + 1]
+            ? focus(event.target, items[index + 1])
+            : group.getAttribute('focusgroup').includes('wrap') &&
+              focus(event.target, items[0])
+        } else {
+          focus(event.target, items[index + 1] || items[0])
+        }
       } else if (event.key === prevKey) {
         event.preventDefault()
-        focus(event.target, items[index - 1] || items[items.length - 1])
+        if (group.hasAttribute('focusgroup')) {
+          items[index - 1]
+            ? focus(event.target, items[index - 1])
+            : group.getAttribute('focusgroup').includes('wrap') &&
+              focus(event.target, items[items.length - 1])
+        } else {
+          focus(event.target, items[index - 1] || items[items.length - 1])
+        }
       } else if (event.key === 'Home') {
         event.preventDefault()
         focus(event.target, items[0])

--- a/focus-group.js
+++ b/focus-group.js
@@ -92,20 +92,22 @@ export function focusGroupKeyUX(options) {
       if (event.key === nextKey) {
         event.preventDefault()
         if (group.hasAttribute('focusgroup')) {
-          items[index + 1]
-            ? focus(event.target, items[index + 1])
-            : group.getAttribute('focusgroup').includes('wrap') &&
-              focus(event.target, items[0])
+          if (items[index + 1]) {
+            focus(event.target, items[index + 1])
+          } else if (group.getAttribute('focusgroup').includes('wrap')) {
+            focus(event.target, items[0])
+          }
         } else {
           focus(event.target, items[index + 1] || items[0])
         }
       } else if (event.key === prevKey) {
         event.preventDefault()
         if (group.hasAttribute('focusgroup')) {
-          items[index - 1]
-            ? focus(event.target, items[index - 1])
-            : group.getAttribute('focusgroup').includes('wrap') &&
-              focus(event.target, items[items.length - 1])
+          if (items[index - 1]) {
+            focus(event.target, items[index - 1])
+          } else if (group.getAttribute('focusgroup').includes('wrap')) {
+            focus(event.target, items[items.length - 1])
+          }
         } else {
           focus(event.target, items[index - 1] || items[items.length - 1])
         }

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
       "import": {
         "./index.js": "{ startKeyUX, hotkeyKeyUX, pressKeyUX, focusGroupKeyUX, jumpKeyUX, hiddenKeyUX, likelyWithKeyboard, getHotKeyHint, hotkeyOverrides, hotkeyMacCompat }"
       },
-      "limit": "2277 B"
+      "limit": "2309 B"
     }
   ],
   "clean-publish": {

--- a/test/demo/index.html
+++ b/test/demo/index.html
@@ -132,7 +132,7 @@
         padding: 0.5em 1em;
         background: #eee;
 
-        &[focusgroup='block'] button {
+        &[focusgroup~='block'] button {
           display: block;
           margin-bottom: 1em;
         }

--- a/test/demo/index.tsx
+++ b/test/demo/index.tsx
@@ -421,7 +421,7 @@ const FocusGroupBlock: FC = () => {
       <div
         className="focusgroup"
         // @ts-expect-error
-        focusgroup="block"
+        focusgroup="block wrap"
         tabIndex={0}
       >
         <button type="button">Dog</button>

--- a/test/focus-group.test.ts
+++ b/test/focus-group.test.ts
@@ -461,10 +461,10 @@ test('adds focusgroup widget', () => {
   let window = new JSDOM().window
   startKeyUX(window, [focusGroupKeyUX()])
   window.document.body.innerHTML =
-    '<div focusgroup tabIndex="-1">' +
-    '<button role="button" tabindex="-1">Mac</button>' +
-    '<button role="button" tabindex="-1">Windows</button>' +
-    '<button role="button" tabindex="-1">Linux</button>' +
+    '<div focusgroup>' +
+    '<button role="button">Mac</button>' +
+    '<button role="button">Windows</button>' +
+    '<button role="button">Linux</button>' +
     '</div>'
   let buttons = window.document.querySelectorAll('button')
   buttons[0].focus()
@@ -480,13 +480,13 @@ test('adds focusgroup widget', () => {
   press(window, 'End')
   equal(window.document.activeElement, buttons[2])
 
+  press(window, 'ArrowRight')
+  equal(window.document.activeElement, buttons[2])
+
   press(window, 'Home')
   equal(window.document.activeElement, buttons[0])
 
   press(window, 'ArrowLeft')
-  equal(window.document.activeElement, buttons[2])
-
-  press(window, 'ArrowRight')
   equal(window.document.activeElement, buttons[0])
 })
 
@@ -494,10 +494,10 @@ test('adds focusgroup inline widget', () => {
   let window = new JSDOM().window
   startKeyUX(window, [focusGroupKeyUX()])
   window.document.body.innerHTML =
-    '<div focusgroup="inline" tabIndex="-1">' +
-    '<button role="button" tabindex="-1">Mac</button>' +
-    '<button role="button" tabindex="-1">Windows</button>' +
-    '<button role="button" tabindex="-1">Linux</button>' +
+    '<div focusgroup="inline">' +
+    '<button role="button">Mac</button>' +
+    '<button role="button">Windows</button>' +
+    '<button role="button">Linux</button>' +
     '</div>'
   let buttons = window.document.querySelectorAll('button')
   buttons[0].focus()
@@ -513,13 +513,13 @@ test('adds focusgroup inline widget', () => {
   press(window, 'End')
   equal(window.document.activeElement, buttons[2])
 
+  press(window, 'ArrowRight')
+  equal(window.document.activeElement, buttons[2])
+
   press(window, 'Home')
   equal(window.document.activeElement, buttons[0])
 
   press(window, 'ArrowLeft')
-  equal(window.document.activeElement, buttons[2])
-
-  press(window, 'ArrowRight')
   equal(window.document.activeElement, buttons[0])
 })
 
@@ -527,13 +527,12 @@ test('adds focusgroup block widget', () => {
   let window = new JSDOM().window
   startKeyUX(window, [focusGroupKeyUX()])
   window.document.body.innerHTML =
-    '<div focusgroup="block" tabIndex="-1">' +
-    '<button role="button" tabindex="-1">Dog</button>' +
-    '<button role="button" tabindex="-1">Cat</button>' +
-    '<button role="button" tabindex="-1">Turtle</button>' +
+    '<div focusgroup="block">' +
+    '<button role="button">Dog</button>' +
+    '<button role="button">Cat</button>' +
+    '<button role="button">Turtle</button>' +
     '</div>'
   let buttons = window.document.querySelectorAll('button')
-  // @ts-ignore
   buttons[0].focus()
 
   equal(window.document.activeElement, buttons[0])
@@ -615,4 +614,37 @@ test('adds toolbar widget with focusgroup block option', () => {
 
   press(window, 'ArrowRight')
   equal(window.document.activeElement, buttons[0])
+})
+
+test('enabling wrap behaviors in focusgroup', () => {
+  let window = new JSDOM().window
+  startKeyUX(window, [focusGroupKeyUX()])
+  window.document.body.innerHTML =
+    '<div focusgroup="inline wrap">' +
+    '<button role="button">Dog</button>' +
+    '<button role="button">Cat</button>' +
+    '<button role="button">Turtle</button>' +
+    '</div>'
+  let buttons = window.document.querySelectorAll('button')
+  buttons[0].focus()
+
+  equal(window.document.activeElement, buttons[0])
+
+  press(window, 'ArrowRight')
+  equal(window.document.activeElement, buttons[1])
+
+  press(window, 'ArrowLeft')
+  equal(window.document.activeElement, buttons[0])
+
+  press(window, 'End')
+  equal(window.document.activeElement, buttons[2])
+
+  press(window, 'ArrowRight')
+  equal(window.document.activeElement, buttons[0])
+
+  press(window, 'Home')
+  equal(window.document.activeElement, buttons[0])
+
+  press(window, 'ArrowLeft')
+  equal(window.document.activeElement, buttons[2])
 })


### PR DESCRIPTION
The `focusgroup=wrap` attribute now allows users to control focus navigation behavior. This change aligns with the active proposal, enabling explicit management of wrapping with the attribute.