### PR TITLE
feat: prevent default browser shortcuts if there is a custom one

### DIFF
--- a/hotkey.js
+++ b/hotkey.js
@@ -106,6 +106,8 @@ export function hotkeyKeyUX(transformers = []) {
       }
       let active = findHotKey(event, window, transformers)
       if (!active) return
+      // Prevent default browser behavior
+      event.preventDefault()
       if (
         active.tagName === 'TEXTAREA' ||
         (active.tagName === 'INPUT' && !CLICK_INPUTS[active.type])


### PR DESCRIPTION
Closes #59 
Prevent default browser behavior for hotkeys.