### PR TITLE
Skip disabled items in focus group navigation

### DIFF
--- a/focus-group.js
+++ b/focus-group.js
@@ -32,6 +32,10 @@ function getItems(target, group) {
 
 function filterNested(allItems, group) {
   return Array.from(allItems).filter(item => {
+    if (item.disabled || item.getAttribute('aria-disabled') === 'true') {
+      return false
+    }
+
     let current = item.parentElement
     while (current && current !== group) {
       if (current.getAttribute('aria-hidden') === 'true') {
@@ -80,7 +84,7 @@ export function focusGroupKeyUX(options) {
 
       let allItems = getItems(event.target, group)
       let items = filterNested(allItems, group)
-      let index = Array.from(items).indexOf(event.target)
+      let index = items.indexOf(event.target)
 
       let nextKey = 'ArrowDown'
       let prevKey = 'ArrowUp'
@@ -114,7 +118,7 @@ export function focusGroupKeyUX(options) {
         }
         lastTyped = event.timeStamp
 
-        let found = Array.from(allItems).find(item => {
+        let found = items.find(item => {
           return item.textContent
             ?.trim()
             ?.toLowerCase()

--- a/test/focus-group.test.ts
+++ b/test/focus-group.test.ts
@@ -204,6 +204,46 @@ describe('focus-group', () => {
     equal(window.document.activeElement, items[3])
   })
 
+  test('skips disabled items', async () => {
+    let window = new JSDOM().window
+    startKeyUX(window, [
+      hotkeyKeyUX(),
+      focusGroupKeyUX({
+        searchDelayMs: 100
+      })
+    ])
+
+    window.document.body.innerHTML =
+      '<nav role="menu">' +
+      '<button role="menuitem">Home</button>' +
+      '<button role="menuitem" disabled>About</button>' +
+      '<button role="menuitem" aria-disabled="true">Blog</button>' +
+      '<button role="menuitem">Contact</button>' +
+      '</nav>'
+
+    let items = window.document.querySelectorAll('button')
+    items[0]!.focus()
+
+    press(window, 'ArrowDown')
+    equal(window.document.activeElement, items[3])
+
+    press(window, 'ArrowUp')
+    equal(window.document.activeElement, items[0])
+
+    press(window, 'End')
+    equal(window.document.activeElement, items[3])
+
+    press(window, 'Home')
+    equal(window.document.activeElement, items[0])
+
+    press(window, 'ArrowUp')
+    equal(window.document.activeElement, items[3])
+
+    await setTimeout(150)
+    press(window, 'b')
+    equal(window.document.activeElement, items[3])
+  })
+
   test('supports RTL locales', () => {
     let window = new JSDOM().window
     startKeyUX(window, [focusGroupKeyUX()])


### PR DESCRIPTION
- Exclude disabled and `aria-disabled="true"` items from focus group navigation
- Prevent typeahead search from focusing disabled items
- Add coverage for arrow, Home/End, wraparound, and typeahead behavior